### PR TITLE
Implement the Date in IST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
-# stable official Java runtime base image
+
+
+# BASE IMAGE - which provides the working environment
 FROM openjdk:17-jdk-alpine
 
-# metadata
-LABEL maintainer="your-email@example.com"
-LABEL version="1.0"
-LABEL description="A simple Java application"
-
-# working directory
+#WORKING DIRECTORY - on which directory will my container run.... if it is copied from source
 WORKDIR /app
 
-# Copy source code into the container
-COPY src/Main.java /app/Main.java
+# Copy the source code from HOST to working directory
+COPY . .
 
-# Compile the Java code
-RUN javac Main.java
+# Install timezone data using Alpine Package Manager
+RUN apk add --no-cache tzdata
 
-# Run the Java application when the container starts
+# Set timezone equal to IST
+ENV TZ=Asia/Kolkata
+
+# Compile the code
+RUN javac src/Main.java -d /app
+
+# Run the Application
 CMD ["java", "Main"]
+

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,8 +1,17 @@
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 public class Main {
     public static void main(String[] args) {
-        Date currentDate = new Date();
+        Date now = new Date();
+
+        SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss z");
+
+        sdf.setTimeZone(TimeZone.getTimeZone("Asia/Kolkata"));
+
+        String currentDate = sdf.format(now);
+
         System.out.println("Hello, Docker! Current date: " + currentDate);
     }
 }


### PR DESCRIPTION
Purpose:
Implement Java application inside Docker container that displays current date and time in Indian Standard Time (IST).

**Changes in Dockerfile:**
Installed timezone data (tzdata) in Alpine-based Docker image:
_RUN apk add --no-cache tzdata_

Set timezone to Asia/Kolkata using:
ENV TZ=Asia/Kolkata
Ensured Java application inside the container uses IST instead of UTC.
Because the container often default UTC, regardless of what timezone your local is used so to make it available inside the docker container I made the docker container to use this timezone

**Changes in Main.java:**
Used SimpleDateFormat and TimeZone classes to format and display the date in IST:

Set TimeZone explicitly:
_sdf.setTimeZone(TimeZone.getTimeZone("Asia/Kolkata"));_
Made sure that the application prints the date in a human-readable format adjusted to IST.

✅ Summary Statement
Implemented timezone configuration in both Docker container and Java application to ensure consistent date-time output in Indian Standard Time (IST), using tzdata installation, ENV TZ in Dockerfile, and Java's SimpleDateFormat with TimeZone setting in Main.java.

<img width="1088" height="52" alt="Screenshot 2025-07-11 093756" src="https://github.com/user-attachments/assets/3b95cce2-8e00-4617-8cd6-ebbb5e104d26" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The application now displays the current date and time in a custom format, localized to the Asia/Kolkata time zone.

* **Chores**
  * Improved Docker container setup by installing timezone data and setting the default timezone to Asia/Kolkata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->